### PR TITLE
fix: allow sensitive secret map in github_actions_secret loop

### DIFF
--- a/infra/github.tf
+++ b/infra/github.tf
@@ -1,5 +1,5 @@
 resource "github_actions_secret" "all_secrets"{
-    for_each = var.secret
+    for_each = nonsensitive(var.secret)
     repository = "Playwright-Meroshare-Automation"
     secret_name = each.key
     plaintext_value = each.value


### PR DESCRIPTION
This pull request makes a small update to the way GitHub Actions secrets are provisioned in the Terraform configuration. The change ensures that secrets are handled as non-sensitive values when iterating over them.

* Updated the `for_each` expression in `infra/github.tf` to use `nonsensitive(var.secret)` instead of `var.secret`, allowing Terraform to iterate over secrets without treating them as sensitive values.